### PR TITLE
Update courts list

### DIFF
--- a/metadata/page/page.location.json
+++ b/metadata/page/page.location.json
@@ -100,12 +100,6 @@
           "value": "939"
         },
         {
-          "_id": "court_code_941",
-          "_type": "option",
-          "text": "Administrative Support Centre Leicestershire Social Security and Child Support Tribunal",
-          "value": "941"
-        },
-        {
           "_id": "court_code_603",
           "_type": "option",
           "text": "Admiralty and Commercial Courts",
@@ -572,6 +566,12 @@
           "_type": "option",
           "text": "Bury St Edmunds County Court",
           "value": "157"
+        },
+        {
+          "_id": "court_code_107",
+          "_type": "option",
+          "text": "Bury St Edmunds Divorce Unit (London and SE)",
+          "value": "107"
         },
         {
           "_id": "court_code_949",
@@ -1378,12 +1378,6 @@
           "value": "10162"
         },
         {
-          "_id": "court_code_10166",
-          "_type": "option",
-          "text": "Harlow Magistrates' Court",
-          "value": "10166"
-        },
-        {
           "_id": "court_code_214",
           "_type": "option",
           "text": "Harrogate County Court",
@@ -1928,12 +1922,6 @@
           "_type": "option",
           "text": "London Probate",
           "value": "5002"
-        },
-        {
-          "_id": "court_code_107",
-          "_type": "option",
-          "text": "London and SE Divorce Centre",
-          "value": "107"
         },
         {
           "_id": "court_code_1027513",
@@ -2558,12 +2546,6 @@
           "_type": "option",
           "text": "Primary Health Lists",
           "value": "909"
-        },
-        {
-          "_id": "court_code_5001",
-          "_type": "option",
-          "text": "Probate GBO",
-          "value": "5001"
         },
         {
           "_id": "court_code_991",

--- a/optics/OPTIC-courts-list.csv
+++ b/optics/OPTIC-courts-list.csv
@@ -232,7 +232,7 @@
 ,,,,,
 ,Divorce Centres,,Divorce Centres,,
 ,East Midlands Divorce Unit,134,East Midlands Divorce Unit,,
-,London & SE Divorce Centre,107,London & SE Divorce Centre,,
+,Bury St Edmunds Divorce Unit (London & SE),107,Bury St Edmunds Divorce Unit (London & SE),,
 ,Newport Divorce Unit,280-A,Newport Divorce Unit,,
 ,North East Divorce Unit,141-A,North East Divorce Unit,,
 ,North West Divorce Unit,251-A,North West Divorce Unit,,

--- a/optics/OPTIC-exclude.txt
+++ b/optics/OPTIC-exclude.txt
@@ -10,3 +10,6 @@ National Taxing Team - Birmingham
 714
 National Taxing Team – Manchester
 715
+941
+5001
+10166

--- a/optics/courts-list-options.json
+++ b/optics/courts-list-options.json
@@ -85,12 +85,6 @@
     "value": "939"
   },
   {
-    "_id": "court_code_941",
-    "_type": "option",
-    "text": "Administrative Support Centre Leicestershire Social Security and Child Support Tribunal",
-    "value": "941"
-  },
-  {
     "_id": "court_code_603",
     "_type": "option",
     "text": "Admiralty and Commercial Courts",
@@ -557,6 +551,12 @@
     "_type": "option",
     "text": "Bury St Edmunds County Court",
     "value": "157"
+  },
+  {
+    "_id": "court_code_107",
+    "_type": "option",
+    "text": "Bury St Edmunds Divorce Unit (London and SE)",
+    "value": "107"
   },
   {
     "_id": "court_code_949",
@@ -1363,12 +1363,6 @@
     "value": "10162"
   },
   {
-    "_id": "court_code_10166",
-    "_type": "option",
-    "text": "Harlow Magistrates' Court",
-    "value": "10166"
-  },
-  {
     "_id": "court_code_214",
     "_type": "option",
     "text": "Harrogate County Court",
@@ -1913,12 +1907,6 @@
     "_type": "option",
     "text": "London Probate",
     "value": "5002"
-  },
-  {
-    "_id": "court_code_107",
-    "_type": "option",
-    "text": "London and SE Divorce Centre",
-    "value": "107"
   },
   {
     "_id": "court_code_1027513",
@@ -2543,12 +2531,6 @@
     "_type": "option",
     "text": "Primary Health Lists",
     "value": "909"
-  },
-  {
-    "_id": "court_code_5001",
-    "_type": "option",
-    "text": "Probate GBO",
-    "value": "5001"
   },
   {
     "_id": "court_code_991",


### PR DESCRIPTION
Courts to remove

* Administrative Support Centre Leicestershire Social Security and Child Support Tribunal (941)
* Probate GBO (5001)
* Harlow Magistrates' Court (Administrative Support Centre Leicestershire Social Security and Child Support Tribunal) (10166)

Courts to rename
* Change ‘London and SE Divorce Centre’ to Bury St Edmunds Divorce Unit (London & SE)