### PR TITLE
Define session duration

### DIFF
--- a/metadata/config/service.json
+++ b/metadata/config/service.json
@@ -9,5 +9,6 @@
   "name": "Complain about a court or tribunal",
   "name:cy": "Gwneud cwyn am lys neu dribiwnlys",
   "pdfHeading": "Complain about a court or tribunal",
-  "phase": "none"
+  "phase": "none",
+  "sessionDuration": 60
 }


### PR DESCRIPTION
Set the session duration to 60 minutes.

The default session duration for the runner platform has been set to 20 minutes. However this form has text fields that merit providing the user with more time to complete the application.

https://trello.com/c/QoSSTIXg/746-default-session-timeout